### PR TITLE
Minor UI tweaks and some hotkeys

### DIFF
--- a/src/defaults/config/hotkeys.lua
+++ b/src/defaults/config/hotkeys.lua
@@ -8,6 +8,7 @@ return {
     -- Camera
     cameraZoomIn = "ctrl + plus",
     cameraZoomOut = "ctrl + minus",
+	cameraResetZoom = "ctrl + 0",
 	cameraHome = "home",
     toggleFullscreen = "f11",
 

--- a/src/defaults/config/hotkeys.lua
+++ b/src/defaults/config/hotkeys.lua
@@ -8,6 +8,7 @@ return {
     -- Camera
     cameraZoomIn = "ctrl + plus",
     cameraZoomOut = "ctrl + minus",
+	cameraHome = "home",
     toggleFullscreen = "f11",
 
     -- Room Movement

--- a/src/defaults/config/hotkeys.lua
+++ b/src/defaults/config/hotkeys.lua
@@ -8,6 +8,7 @@ return {
     -- Camera
     cameraZoomIn = "ctrl + plus",
     cameraZoomOut = "ctrl + minus",
+    toggleFullscreen = "f11",
 
     -- Room Movement
     roomMoveLeft = "alt + left",

--- a/src/scenes/editor.lua
+++ b/src/scenes/editor.lua
@@ -36,8 +36,8 @@ function editorScene:draw()
 
         self.celesteRender.drawMap(self.viewerState)
 
-        love.graphics.printf("FPS: " .. tostring(love.timer.getFPS()), 20, 40, self.viewerState.viewport.width, "left", 0, self.fonts.fontScale, self.fonts.fontScale)
-        love.graphics.printf(itemName, 20, 80, self.viewerState.viewport.width, "left", 0, self.fonts.fontScale, self.fonts.fontScale)
+        love.graphics.printf("FPS: " .. tostring(love.timer.getFPS()), 20, 20, self.viewerState.viewport.width, "left", 0, self.fonts.fontScale, self.fonts.fontScale)
+        love.graphics.printf(itemName, 20, 60, self.viewerState.viewport.width, "left", 0, self.fonts.fontScale, self.fonts.fontScale)
     end
 
     self:propagateEvent("draw")

--- a/src/standard_hotkeys.lua
+++ b/src/standard_hotkeys.lua
@@ -48,6 +48,7 @@ local rawHotkeys = {
     -- Camera
     {configs.hotkeys.cameraZoomIn, viewportHandler.zoomIn, "Zoom in"},
     {configs.hotkeys.cameraZoomOut, viewportHandler.zoomOut, "Zoom out"},
+    {configs.hotkeys.cameraHome, viewportHandler.home, "Reset camera position and scale"},
     {configs.hotkeys.toggleFullscreen, viewportHandler.toggleFullscreen, "Toggle fullscreen"},
 }
 

--- a/src/standard_hotkeys.lua
+++ b/src/standard_hotkeys.lua
@@ -48,6 +48,7 @@ local rawHotkeys = {
     -- Camera
     {configs.hotkeys.cameraZoomIn, viewportHandler.zoomIn, "Zoom in"},
     {configs.hotkeys.cameraZoomOut, viewportHandler.zoomOut, "Zoom out"},
+    {configs.hotkeys.toggleFullscreen, viewportHandler.toggleFullscreen, "Toggle fullscreen"},
 }
 
 local hotkeys = {}

--- a/src/standard_hotkeys.lua
+++ b/src/standard_hotkeys.lua
@@ -48,6 +48,7 @@ local rawHotkeys = {
     -- Camera
     {configs.hotkeys.cameraZoomIn, viewportHandler.zoomIn, "Zoom in"},
     {configs.hotkeys.cameraZoomOut, viewportHandler.zoomOut, "Zoom out"},
+    {configs.hotkeys.cameraResetZoom, viewportHandler.resetZoom, "Reset Zoom"},
     {configs.hotkeys.cameraHome, viewportHandler.home, "Reset camera position and scale"},
     {configs.hotkeys.toggleFullscreen, viewportHandler.toggleFullscreen, "Toggle fullscreen"},
 }

--- a/src/tools/brush.lua
+++ b/src/tools/brush.lua
@@ -210,7 +210,7 @@ function tool.draw()
 
         local hudText = string.format("Cursor: %s, %s (%s, %s)", tx + 1, ty + 1, px, py)
 
-        love.graphics.printf(hudText, 20, 120, viewportHandler.viewport.width, "left", 0, fonts.fontScale, fonts.fontScale)
+        love.graphics.printf(hudText, 20, 100, viewportHandler.viewport.width, "left", 0, fonts.fontScale, fonts.fontScale)
 
         viewportHandler.drawRelativeTo(room.x, room.y, function()
             drawing.callKeepOriginalColor(function()

--- a/src/viewport_handler.lua
+++ b/src/viewport_handler.lua
@@ -83,6 +83,12 @@ function viewportHandler.zoomOut()
     viewport.y = (viewport.y - mouseY) / 2
 end
 
+function viewportHandler.home()
+	viewport.scale = 1
+	viewport.x = 0
+	viewport.y = 0
+end
+
 function viewportHandler.toggleFullscreen()
 	local fullscreen, fstype = love.window.getFullscreen()
 	love.window.setFullscreen(not fullscreen, fstype)

--- a/src/viewport_handler.lua
+++ b/src/viewport_handler.lua
@@ -83,6 +83,10 @@ function viewportHandler.zoomOut()
     viewport.y = (viewport.y - mouseY) / 2
 end
 
+function viewportHandler.resetZoom()
+    viewport.scale = 1
+end
+
 function viewportHandler.home()
 	viewport.scale = 1
 	viewport.x = 0

--- a/src/viewport_handler.lua
+++ b/src/viewport_handler.lua
@@ -83,6 +83,11 @@ function viewportHandler.zoomOut()
     viewport.y = (viewport.y - mouseY) / 2
 end
 
+function viewportHandler.toggleFullscreen()
+	local fullscreen, fstype = love.window.getFullscreen()
+	love.window.setFullscreen(not fullscreen, fstype)
+end
+
 function viewportHandler.moveToPosition(x, y, scale, centered)
     if scale then
         viewport.scale = scale


### PR DESCRIPTION
*Now 100% mouse wrapping free!* 😢

Changes the text position to be "symmetric", and adds a few hotkeys:
- F11: fullscreen - alt + enter might be better? Also I didn't explicitly set the mode, it seems to default to borderless
- ctrl + 0: Reset zoom - For some reason a lot of hotkeys don't work for me so I didn't really test it, also needs calculation for the viewport position...
- ctrl + Home: Reset zoom and position - might be a bit useless

I know this PR is a bit useless but I got a bit more familiar with the codebase when making it, hopefully I can tackle some more useful things.