### PR TITLE
include menu name in submenu keys, and rename room "configure" to "edit"

### DIFF
--- a/src/ui/lang/en_gb.lang
+++ b/src/ui/lang/en_gb.lang
@@ -74,44 +74,44 @@ forms.fieldTypes.unknown_type.label=Unknown field for type '%s' in field '%s'
 
 # Menubar
 ui.menubar.file=File
-ui.menubar.new=New
-ui.menubar.open=Open
-ui.menubar.recent=Recent
-ui.menubar.save=Save
-ui.menubar.save_as=Save as
-ui.menubar.exit=Exit
+ui.menubar.file_new=New
+ui.menubar.file_open=Open
+ui.menubar.file_recent=Recent
+ui.menubar.file_save=Save
+ui.menubar.file_save_as=Save as
+ui.menubar.file_exit=Exit
 
 ui.menubar.edit=Edit
-ui.menubar.undo=Undo
-ui.menubar.redo=Redo
-ui.menubar.settings=Settings
+ui.menubar.edit_undo=Undo
+ui.menubar.edit_redo=Redo
+ui.menubar.edit_settings=Settings
 
 ui.menubar.view=View
 
 ui.menubar.map=Map
-ui.menubar.stylegrounds=Stylegrounds
-ui.menubar.metadata=Metadata
+ui.menubar.map_stylegrounds=Stylegrounds
+ui.menubar.map_metadata=Metadata
 
 ui.menubar.room=Room
-ui.menubar.add=Add
-ui.menubar.configure=Configure
-ui.menubar.delete=Delete
+ui.menubar.room_add=Add
+ui.menubar.room_edit=Edit
+ui.menubar.room_delete=Delete
 
 ui.menubar.debug=Debug
-ui.menubar.reload=Reload
-ui.menubar.reload_everything=Everything
-ui.menubar.reload_scenes=Scenes
-ui.menubar.reload_tools=Tools
-ui.menubar.reload_entities=Entities
-ui.menubar.reload_triggers=Triggers
-ui.menubar.reload_effects=Effects
-ui.menubar.reload_user_interface=User Interface
-ui.menubar.reload_language_files=Language Files
-ui.menubar.redraw_map=Redraw Map
-ui.menubar.test_console=Test Console
+ui.menubar.debug_reload=Reload
+ui.menubar.debug_reload_everything=Everything
+ui.menubar.debug_reload_scenes=Scenes
+ui.menubar.debug_reload_tools=Tools
+ui.menubar.debug_reload_entities=Entities
+ui.menubar.debug_reload_triggers=Triggers
+ui.menubar.debug_reload_effects=Effects
+ui.menubar.debug_reload_user_interface=User Interface
+ui.menubar.debug_reload_language_files=Language Files
+ui.menubar.debug_redraw_map=Redraw Map
+ui.menubar.debug_test_console=Test Console
 
 ui.menubar.help=Help
-ui.menubar.about=About
-ui.menubar.check_for_updates=Check For Updates
+ui.menubar.help_about=About
+ui.menubar.help_check_for_updates=Check For Updates
 
 ui.menubar.not_yet_implemented=This feature is not implemented yet.

--- a/src/ui/menubar.lua
+++ b/src/ui/menubar.lua
@@ -45,18 +45,18 @@ end
 
 local addDebug = configs.debug.enableDebugOptions
 local debugMenu = {"debug", {
-    {"reload", {
-        {"reload_everything", debugUtils.reloadEverything},
-        {"reload_scenes", debugUtils.reloadScenes},
-        {"reload_tools", debugUtils.reloadTools},
-        {"reload_entities", debugUtils.reloadEntities},
-        {"reload_triggers", debugUtils.reloadTriggers},
-        {"reload_effects", notYetImplementedNotification},
-        {"reload_user_interface", reloadUI},
-        {"reload_language_files", debugUtils.reloadLanguageFiles}
+    {"debug_reload", {
+        {"debug_reload_everything", debugUtils.reloadEverything},
+        {"debug_reload_scenes", debugUtils.reloadScenes},
+        {"debug_reload_tools", debugUtils.reloadTools},
+        {"debug_reload_entities", debugUtils.reloadEntities},
+        {"debug_reload_triggers", debugUtils.reloadTriggers},
+        {"debug_reload_effects", notYetImplementedNotification},
+        {"debug_reload_user_interface", reloadUI},
+        {"debug_reload_language_files", debugUtils.reloadLanguageFiles}
     }},
-    {"redraw_map", debugUtils.redrawMap},
-    {"test_console", debugUtils.debug}
+    {"debug_redraw_map", debugUtils.redrawMap},
+    {"debug_test_console", debugUtils.debug}
 }}
 
 -- Tree of menubar items
@@ -66,37 +66,37 @@ local debugMenu = {"debug", {
 -- Closes by default, some menu items might not want to close the menu, for example "View" toggles
 menubar.menubar = {
     {"file", {
-        {"new", loadedState.newMap},
-        {"open", loadedState.openMap},
-        {"recent", notYetImplementedNotification},
+        {"file_new", loadedState.newMap},
+        {"file_open", loadedState.openMap},
+        {"file_recent", notYetImplementedNotification},
         {},
-        {"save", loadedState.saveCurrentMap},
-        {"save_as", loadedState.saveAsCurrentMap},
+        {"file_save", loadedState.saveCurrentMap},
+        {"file_save_as", loadedState.saveAsCurrentMap},
         {},
-        {"exit", love.event.quit}
+        {"file_exit", love.event.quit}
     }},
     {"edit", {
-        {"undo", history.undo},
-        {"redo", history.redo},
+        {"edit_undo", history.undo},
+        {"edit_redo", history.redo},
         {},
-        {"settings", notYetImplementedNotification}
+        {"edit_settings", notYetImplementedNotification}
     }},
     {"view", notYetImplementedNotification},
     {"map", {
-        {"stylegrounds", stylegroundEditor.editStylegrounds},
-        {"metadata", notYetImplementedNotification}
+        {"map_stylegrounds", stylegroundEditor.editStylegrounds},
+        {"map_metadata", notYetImplementedNotification}
     }},
     {"room", {
-        {"add", roomEditor.createNewRoom},
-        {"configure", roomEditor.editExistingRoom},
+        {"room_add", roomEditor.createNewRoom},
+        {"room_edit", roomEditor.editExistingRoom},
         {},
-        {"delete", deleteCurrentRoom}
+        {"room_delete", deleteCurrentRoom}
     }},
     -- Only add if enabled
     addDebug and debugMenu or false,
     {"help", {
-        {"check_for_updates", checkForUpdates},
-        {"about", notYetImplementedNotification}
+        {"help_check_for_updates", checkForUpdates},
+        {"help_about", notYetImplementedNotification}
     }}
 }
 


### PR DESCRIPTION
it seemed to me that `ui.menubar.save` should be `ui.menubar.file_save`, because it's the _file/save_ menu item.
also, the _room/configure_ button opens the edit window, so i changed it to read "edit" instead