### PR TITLE
Fix OS X falling back to Linux message.

### DIFF
--- a/src/scenes/startup.lua
+++ b/src/scenes/startup.lua
@@ -19,7 +19,7 @@ startupScene._performedGameScan = false
 startupScene._dialogChannel = nil
 startupScene._dialogThread = nil
 startupScene._nextScene = "Loading"
-startupScene._messageKey = string.lower(utils.getOS())
+startupScene._messageKey = string.gsub(string.lower(utils.getOS()), " ", "_")
 
 -- Save the path to config and then change to the loading scene
 local function saveGotoLoading(path)


### PR DESCRIPTION
This PR fixes an oversight where Love returns "os x" while the translation file expects "os_x".