### PR TITLE
Listing some basic depths under 'decals' option

### DIFF
--- a/src/decals.lua
+++ b/src/decals.lua
@@ -443,7 +443,35 @@ function decals.fieldInformation(layer, decal)
         },
         depth = {
             fieldType = "integer",
-            allowEmpty = true
+            allowEmpty = true,
+            options = {
+                ["BGTerrain 10000"] = 10000,
+                ["BGMirrors 9500"] = 9500,
+                ["BGDecals 9000"] = 9000,
+                ["BGParticles 8000"] = 8000,
+                ["SolidsBelow 5000"] = 5000,
+                ["Below 2000"] = 2000,
+                ["NPCs 1000"] = 1000,
+                ["TheoCrystal 100"] = 100,
+                ["Player 0"] = 0,
+                ["Dust -50"] = -50,
+                ["Pickups -100"] = -100,
+                ["Seeker -200"] = -200,
+                ["Particles -8000"] = -8000,
+                ["Above -8500"] = -8500,
+                ["Solids -9000"] = -9000,
+                ["FGTerrain -10000"] = -10000,
+                ["FGDecals -10500"] = -10500,
+                ["DreamBlocks -11000"] = -11000,
+                ["CrystalSpinners -11500"] = -11500,
+                ["PlayerDreamDashing -12000"] = -12000,
+                ["Enemy -12500"] = -12500,
+                ["FakeWalls -13000"] = -13000,
+                ["FGParticles -50000"] = -50000,
+                ["Top -1000000"] = -1000000,
+                ["FormationSequences -2000000"] = -2000000
+            },
+            editable = true,
         }
     }
 end


### PR DESCRIPTION
Listing some basic depths constants underneath the depth field so that mappers can have a quick choice on which layer they want the decal to be on