### PR TITLE
UI add plugin groups

### DIFF
--- a/src/entities.lua
+++ b/src/entities.lua
@@ -1308,6 +1308,16 @@ function entities.ignoredFieldsMultiple(layer, entity)
     return alwaysIgnoredFieldsMultiple
 end
 
+function entities.groups(layer, entity)
+    local handler = entities.getHandler(entity)
+
+    if handler and handler.groups then
+        return utils.callIfFunction(handler.groups, entity)
+    end
+
+    return nil
+end
+
 function entities.fieldOrder(layer, entity)
     local handler = entities.getHandler(entity)
 

--- a/src/triggers.lua
+++ b/src/triggers.lua
@@ -792,6 +792,16 @@ function triggers.ignoredFieldsMultiple(layer, trigger)
     return alwaysIgnoredFieldsMultiple
 end
 
+function triggers.groups(layer, trigger)
+    local handler = triggers.getHandler(trigger)
+    
+    if handler and handler.groups then
+        return utils.callIfFunction(handler.groups, trigger)
+    end
+
+    return nil
+end
+
 function triggers.fieldOrder(layer, trigger)
     local defaultFieldOrder = {"x", "y", "width", "height"}
     local handler = triggers.getHandler(trigger)

--- a/src/ui/utils/forms.lua
+++ b/src/ui/utils/forms.lua
@@ -17,6 +17,12 @@ local function getLanguageKey(key, language, default)
     return default
 end
 
+local function getItemGroups(handler, ...)
+    local fieldOrder = utils.callIfFunction(handler and handler.groups, ...)
+
+    return fieldOrder and utils.deepcopy(fieldOrder) or nil
+end
+
 local function getItemFieldOrder(handler, ...)
     local fieldOrder = utils.callIfFunction(handler and handler.fieldOrder, ...) or {}
 
@@ -73,6 +79,7 @@ function formUtils.prepareFormData(handler, data, options, handlerArguments)
     local addMissingToFieldOrder = options.addMissingToFieldOrder
 
     local fieldsAdded = {}
+    local fieldGroups = getItemGroups(handler, unpack(handlerArguments))
     local fieldInformation = getItemFieldInformation(handler, unpack(handlerArguments))
     local fieldOrderOriginal = getItemFieldOrder(handler, unpack(handlerArguments))
     local fieldIgnored = getItemIgnoredFields(handler, options.multiple, unpack(handlerArguments))
@@ -160,7 +167,7 @@ function formUtils.prepareFormData(handler, data, options, handlerArguments)
         fieldInformation[field].tooltipText = tooltip
     end
 
-    return dummyData, fieldInformation, fieldOrder
+    return dummyData, fieldInformation, fieldOrder, fieldGroups
 end
 
 return formUtils

--- a/src/ui/windows/selection_context_window.lua
+++ b/src/ui/windows/selection_context_window.lua
@@ -148,7 +148,7 @@ function contextWindow.createContextMenu(selections, bestSelection, room)
         return
     end
 
-    local dummyData, fieldInformation, fieldOrder = prepareFormData(selections, bestSelection, language)
+    local dummyData, fieldInformation, fieldOrder, fieldGroups = prepareFormData(selections, bestSelection, language)
     local keyCount = utils.countKeys
 
     -- Window would be empty, nothing to show
@@ -167,6 +167,7 @@ function contextWindow.createContextMenu(selections, bestSelection, room)
     local windowTitle = getWindowTitle(language, selections, bestSelection)
     local selectionForm, formFields = form.getForm(buttons, dummyData, {
         fields = fieldInformation,
+        groups = groups,
         fieldOrder = fieldOrder,
         fieldMetadata = {
             formData = dummyData,


### PR DESCRIPTION
This PR allows entity and trigger plugins to create groups instead or with fieldOrder to mimic the structure the Settings window has, as in, where each "row" has a small title to indicate what they do.